### PR TITLE
Fix bug when closing the socket

### DIFF
--- a/LibThreadedSockets/ThreadedServer.cs
+++ b/LibThreadedSockets/ThreadedServer.cs
@@ -101,6 +101,7 @@ namespace LibThreadedSockets
             foreach(ClientConnection clientConnection in Connections.ToArray())
                 DisconnectClient(clientConnection);
 
+            socket.Shutdown(SocketShutdown.Both);
             socket.Close();
 
             Connections.Clear();


### PR DESCRIPTION
A bug appears when closing the socket:
'Cannot access a disposed object. Object name: System.Net.Sockets.Socket.'

According to the documentation, a 'Shutdown' should always be called before closing the Socket:
[https://learn.microsoft.com/en-us/dotnet/api/System.Net.Sockets.Socket.Close?view=netframework-4.8](https://learn.microsoft.com/en-us/dotnet/api/System.Net.Sockets.Socket.Close?view=netframework-4.8)

Would it be possible to compile another version and update NuGet?

Many thanks!